### PR TITLE
ITC-3608: Security: Special crafted custom header or query string parameter can disable CSRF protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,6 +157,7 @@ plugins/GudeModule
 plugins/PaloAltoModule
 plugins/RaritanModule
 plugins/SonicWallModule
+plugins/SymantecModule
 
 # NFS mounts
 .nfs.*

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ plugins/GudeModule
 plugins/PaloAltoModule
 plugins/RaritanModule
 plugins/SonicWallModule
+plugins/AristaNetworksModule
 
 # NFS mounts
 .nfs.*

--- a/config/routes.php
+++ b/config/routes.php
@@ -22,7 +22,6 @@
 //     License agreement and license key will be shipped with the order
 //     confirmation.
 
-use Cake\Http\Middleware\CsrfProtectionMiddleware;
 use Cake\Routing\Route\InflectedRoute;
 use Cake\Routing\RouteBuilder;
 
@@ -55,47 +54,6 @@ $routes->setRouteClass(InflectedRoute::class);
 $routes->setExtensions(['json', 'html', 'pdf', 'png', 'zip']);
 
 $routes->scope('/', function (RouteBuilder $builder) {
-    // Register scoped middleware for in scopes.
-    $csrf = new CsrfProtectionMiddleware([
-        'httponly' => true,
-        'secure'   => true
-    ]);
-
-    // Token check will be skipped when callback returns `true`.
-    $csrf->skipCheckCallback(function ($request) {
-        // Skip token check for API URLs.
-        if (get_class($request) !== 'Cake\\Http\\ServerRequest') {
-            // I'm not sure if $request can be something else because the docs is not clear about this
-            return false;
-        }
-
-        if (strtolower($request->getParam('controller')) === 'hosts' && $request->getParam('action') === 'index') {
-            // Disable CSRF check for /hosts/index ITC-2640
-            return true;
-        }
-
-        if (strtolower($request->getParam('controller')) === 'services' && $request->getParam('action') === 'index') {
-            // Disable CSRF check for /services/index ITC-3349
-            return true;
-        }
-
-        // Keep CSRF checks enabled
-        return false;
-    });
-
-    $builder->registerMiddleware('csrf', $csrf);
-
-    /*
-     * Apply a middleware to the current route scope.
-     * Requires middleware to be registered through `Application::routes()` with `registerMiddleware()`
-     */
-    if (
-        (!isset($_SERVER['HTTP_AUTHORIZATION']) || (isset($_SERVER['HTTP_AUTHORIZATION']) && strpos($_SERVER['HTTP_AUTHORIZATION'], 'X-OITC-API') === false)) &&
-        (!isset($_SERVER['QUERY_STRING']) || (isset($_SERVER['QUERY_STRING']) && strpos($_SERVER['QUERY_STRING'], 'apikey') === false))) {
-
-        $builder->applyMiddleware('csrf');
-    }
-
     /*
      * Fireup the AngularJS application
      */

--- a/plugins/GrafanaModule/src/Command/ServiceAccountCommand.php
+++ b/plugins/GrafanaModule/src/Command/ServiceAccountCommand.php
@@ -473,8 +473,8 @@ class ServiceAccountCommand extends Command {
 
             // Disable HTTP proxy
             'proxy'           => [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ]
         ];
 

--- a/plugins/GrafanaModule/src/Model/Table/GrafanaConfigurationsTable.php
+++ b/plugins/GrafanaModule/src/Model/Table/GrafanaConfigurationsTable.php
@@ -217,8 +217,8 @@ class GrafanaConfigurationsTable extends Table {
             ];
         } else {
             $options['proxy'] = [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ];
         }
         $client = new Client($options);

--- a/plugins/MattermostModule/src/Command/MattermostNotificationCommand.php
+++ b/plugins/MattermostModule/src/Command/MattermostNotificationCommand.php
@@ -575,8 +575,8 @@ class MattermostNotificationCommand extends Command {
             ];
         } else {
             $options['proxy'] = [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ];
         }
 

--- a/plugins/PuppeteerPdf/src/Pdf/PuppeteerClient.php
+++ b/plugins/PuppeteerPdf/src/Pdf/PuppeteerClient.php
@@ -34,8 +34,8 @@ class PuppeteerClient {
         $this->Client = new Client([
             'base_uri' => $this->address,
             'proxy'    => [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ]
         ]);
     }

--- a/src/Application.php
+++ b/src/Application.php
@@ -22,7 +22,6 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
-//
 
 namespace App;
 
@@ -271,6 +270,10 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             'secure'   => true,
             'samesite' => CookieInterface::SAMESITE_LAX
         ]);
+
+        // pass skipCsrfCheck as callback method. This is the new php 8.1 syntax. in older php versions we used to write it like so
+        // $csrfProtectionMiddleware->skipCheckCallback([$this, 'skipCsrfCheck']);
+        // but the old array method is not very IDE and type safety friendly.
         $csrfProtectionMiddleware->skipCheckCallback($this->skipCsrfCheck(...));
 
         return $csrfProtectionMiddleware;

--- a/src/Application.php
+++ b/src/Application.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App;
 
@@ -109,24 +110,6 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
         }
 
         $this->addPlugin('Dbml');
-    }
-
-    /**
-     * Define the routes for an application.
-     *
-     * Use the provided RouteBuilder to define an application's routing, register scoped middleware.
-     *
-     * @param \Cake\Routing\RouteBuilder $routes A route builder to add routes into.
-     * @return void
-     */
-    public function routes($routes): void {
-        // Register scoped middleware for use in routes.php
-        $routes->registerMiddleware('csrf', new CsrfProtectionMiddleware([
-            'httponly' => true,
-            'secure'   => true
-        ]));
-
-        parent::routes($routes);
     }
 
     /**
@@ -251,7 +234,6 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
     public function middleware($middlewareQueue): MiddlewareQueue {
         $middlewareQueue
             //->add(new CorsMiddleware())
-
             ->add(new BodyParserMiddleware())
 
             // Catch any exceptions in the lower layers,
@@ -276,8 +258,52 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             ]))
             ->add(new LdapUsergroupIdMiddleware()) // ITC-2693
             ->add(new AuthorizationMiddleware($this))
-            ->add(new RequestAuthorizationMiddleware());
+            ->add(new RequestAuthorizationMiddleware())
+            ->add($this->buildCsrfMiddleware());
 
         return $middlewareQueue;
     }
+
+    private function buildCsrfMiddleware(): CsrfProtectionMiddleware {
+        $csrfProtectionMiddleware = new CsrfProtectionMiddleware([
+            'httponly' => true,
+            'secure'   => true
+        ]);
+        $csrfProtectionMiddleware->skipCheckCallback($this->skipCsrfCheck(...));
+
+        return $csrfProtectionMiddleware;
+    }
+
+    /**
+     * Token check will be skipped when this returns `true`.
+     *
+     * @param ServerRequestInterface $request
+     * @return bool
+     */
+    private function skipCsrfCheck(ServerRequestInterface $request): bool {
+        // Controller/action pairs without CSRF protection (lowercase)
+        $skipActions = [
+            'hosts.index',    // ITC-2640
+            'services.index', // ITC-3349
+        ];
+
+        // ITC-3806: Disable CSRF check for users authenticated with API Token.
+        $service = $request->getAttribute('authentication');
+        if ($service instanceof AuthenticationServiceInterface
+            && $service->getAuthenticationProvider() instanceof ApikeyAuthenticator
+        ) {
+            return true;
+        }
+
+        $params = $request->getAttribute('params', []);
+        if (!empty($params['plugin']) || !empty($params['prefix'])) {
+            // Only exempt actions of the main application
+            return false;
+        }
+
+        $key = strtolower(sprintf('%s.%s', $params['controller'] ?? '', $params['action'] ?? ''));
+
+        return in_array($key, $skipActions, true);
+    }
+
 }

--- a/src/Command/GearmanWorkerCommand.php
+++ b/src/Command/GearmanWorkerCommand.php
@@ -1421,7 +1421,10 @@ class GearmanWorkerCommand extends Command {
         $gearmanClient = new \GearmanClient();
         $gearmanClient->addServer($gearmanConfig['address'], $gearmanConfig['port']);
         //This callback gets called, for any finished export task (like hosttemplates, services etc...)
-        $gearmanClient->setCompleteCallback([$this, 'exportCallback']);
+        // pass exportCallback as callback method. This is the new php 8.1 syntax. in older php versions we used to write it like so
+        // $gearmanClient->setCompleteCallback([$this, 'exportCallback']);
+        // but the old array method is not very IDE and type safety friendly.
+        $gearmanClient->setCompleteCallback($this->exportCallback(...));
 
         //Delete old configuration
         $entity = $ExportsTable->newEntity([

--- a/src/Command/PushoverNotificationCommand.php
+++ b/src/Command/PushoverNotificationCommand.php
@@ -341,14 +341,14 @@ class PushoverNotificationCommand extends Command {
                 'message' => $message
             ],
             'proxy'       => [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ]
         ];
 
         $params['proxy'] = [
-            'http'  => false,
-            'https' => false
+            'http'  => '',
+            'https' => ''
         ];
         if ($this->useProxy) {
             /** @var ProxiesTable $ProxiesTable */

--- a/src/Command/SystemMetricsCommand.php
+++ b/src/Command/SystemMetricsCommand.php
@@ -100,8 +100,8 @@ class SystemMetricsCommand extends Command implements CronjobInterface {
         $params = [
             'form_params' => $dataToSend,
             'proxy'       => [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ]
         ];
 

--- a/src/Controller/HostsController.php
+++ b/src/Controller/HostsController.php
@@ -137,7 +137,6 @@ class HostsController extends AppController {
     const PARENTS_CHILDREN_TREE_CHILDREN_GROUP = "hostChildrenGroup";
 
     public function index() {
-        /** @var User $User */
         $User = new User($this->getUser());
 
         /** @var SystemsettingsTable $SystemsettingsTable */
@@ -150,7 +149,7 @@ class HostsController extends AppController {
         $satellites = [];
 
         if (Plugin::isLoaded('DistributeModule')) {
-            /** @var \DistributeModule\Model\Table\SatellitesTable $SatellitesTable */
+            /** @var SatellitesTable $SatellitesTable */
             $SatellitesTable = TableRegistry::getTableLocator()->get('DistributeModule.Satellites');
 
             $satellites = $SatellitesTable->getSatellitesAsListWithDescription($this->MY_RIGHTS);
@@ -216,6 +215,7 @@ class HostsController extends AppController {
             //$modelName = 'Hoststatus';
         }
 
+        $hosts = [];
         if ($this->DbBackend->isStatusengine3()) {
             $hosts = $HostsTable->getHostsIndexStatusengine3($HostFilter, $HostCondition, $PaginateOMat);
         }
@@ -336,6 +336,8 @@ class HostsController extends AppController {
 
             $all_hosts[] = $tmpRecord;
         }
+
+
         $this->set('all_hosts', $all_hosts);
         $this->set('username', $User->getFullName());
         $this->viewBuilder()->setOption('serialize', ['all_hosts', 'username']);
@@ -538,7 +540,7 @@ class HostsController extends AppController {
             if ($this->hasRootPrivileges === false) {
                 $MY_RIGHTS = $this->MY_RIGHTS;
             }
-            /** @var $SatellitesTable \DistributeModule\Model\Table\SatellitesTable */
+            /** @var $SatellitesTable SatellitesTable */
             $SatellitesTable = TableRegistry::getTableLocator()->get('DistributeModule.Satellites');
             $SatelliteNames = $SatellitesTable->getSatellitesAsListWithDescription($MY_RIGHTS);
             $SatelliteNames[0] = $masterInstanceName;
@@ -1486,7 +1488,7 @@ class HostsController extends AppController {
             if ($this->hasRootPrivileges === false) {
                 $MY_RIGHTS = $this->MY_RIGHTS;
             }
-            /** @var $SatellitesTable \DistributeModule\Model\Table\SatellitesTable */
+            /** @var $SatellitesTable SatellitesTable */
             $SatellitesTable = TableRegistry::getTableLocator()->get('DistributeModule.Satellites');
             $SatelliteNames = $SatellitesTable->getSatellitesAsListWithDescription($MY_RIGHTS);
             $SatelliteNames[0] = $masterInstanceName;
@@ -2537,7 +2539,6 @@ class HostsController extends AppController {
             (int)$id,
             Hash::extract($mergedHost, 'hostgroups.{n}.id')
         );
-        //dd($hasHostDependencies);
         $MY_RIGHTS = $this->MY_RIGHTS;
         if ($this->hasRootPrivileges) {
             $MY_RIGHTS = [];
@@ -2648,7 +2649,7 @@ class HostsController extends AppController {
 
         $satellites = [];
         if (Plugin::isLoaded('DistributeModule')) {
-            /** @var \DistributeModule\Model\Table\SatellitesTable $SatellitesTable */
+            /** @var SatellitesTable $SatellitesTable */
             $SatellitesTable = TableRegistry::getTableLocator()->get('DistributeModule.Satellites');
 
             $satellites = $SatellitesTable->getSatellitesAsListWithDescription($this->MY_RIGHTS);
@@ -2762,7 +2763,7 @@ class HostsController extends AppController {
 
         $satellites = [];
         if (Plugin::isLoaded('DistributeModule')) {
-            /** @var \DistributeModule\Model\Table\SatellitesTable $SatellitesTable */
+            /** @var SatellitesTable $SatellitesTable */
             $SatellitesTable = TableRegistry::getTableLocator()->get('DistributeModule.Satellites');
 
             $satellites = $SatellitesTable->getSatellitesAsListWithDescription($this->MY_RIGHTS);

--- a/src/Model/Table/WizardAssignmentsTable.php
+++ b/src/Model/Table/WizardAssignmentsTable.php
@@ -664,6 +664,14 @@ class WizardAssignmentsTable extends Table {
                 'image'       => 'sonicwall.svg',
                 'category'    => ['cloud', 'network'],
                 'active'      => true
+            ],
+            'symantec-mail-gateway'        => [
+                'type_id'     => 'symantec-mail-gateway',
+                'title'       => __('Symantec Mail Gateway'),
+                'description' => __('Monitor your Symantec Mail Gateway via SNMP.'),
+                'image'       => 'symantec.svg',
+                'category'    => ['network', 'mail'],
+                'active'      => true
             ]
         ];
 

--- a/src/Model/Table/WizardAssignmentsTable.php
+++ b/src/Model/Table/WizardAssignmentsTable.php
@@ -664,6 +664,14 @@ class WizardAssignmentsTable extends Table {
                 'image'       => 'sonicwall.svg',
                 'category'    => ['cloud', 'network'],
                 'active'      => true
+            ],
+            'arista-network'               => [
+                'type_id'     => 'arista-network',
+                'title'       => __('Arista Network'),
+                'description' => __('Monitor your Arista network via SNMP.'),
+                'image'       => 'arista-networks.svg',
+                'category'    => ['network', 'hardware'],
+                'active'      => true
             ]
         ];
 

--- a/src/itnovum/openITCOCKPIT/Agent/AgentHttpClient.php
+++ b/src/itnovum/openITCOCKPIT/Agent/AgentHttpClient.php
@@ -403,8 +403,8 @@ class AgentHttpClient {
             ],
             'verify'  => true,
             'proxy'   => [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ],
             'timeout' => 30
         ];

--- a/src/itnovum/openITCOCKPIT/Core/NodeJS/ChartRenderClient.php
+++ b/src/itnovum/openITCOCKPIT/Core/NodeJS/ChartRenderClient.php
@@ -86,8 +86,8 @@ class ChartRenderClient {
         $this->Client = new Client([
             'base_uri' => $this->address,
             'proxy'    => [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ]
         ]);
     }

--- a/src/itnovum/openITCOCKPIT/Core/PackagemanagerRequestHandler.php
+++ b/src/itnovum/openITCOCKPIT/Core/PackagemanagerRequestHandler.php
@@ -187,8 +187,8 @@ class PackagemanagerRequestHandler {
             ];
         } else {
             $options['proxy'] = [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ];
         }
         return $options;

--- a/src/itnovum/openITCOCKPIT/Core/Permissions/MyRightsFactory.php
+++ b/src/itnovum/openITCOCKPIT/Core/Permissions/MyRightsFactory.php
@@ -110,9 +110,13 @@ class MyRightsFactory {
             foreach ($ContainersTable->getChildren($container['container_id']) as $childContainer) {
                 $MY_RIGHTS[] = (int)$childContainer['id'];
                 $MY_RIGHTS_LEVEL[(int)$childContainer['id']] = $container['permission_level'];
+                // ITC-3418 Container authorizations are not properly implemented
+                // do not override existing permissions with lower permission levels from parent containers
+                if (isset($containerPermissions[$childContainer['id']]) && $containerPermissions[$childContainer['id']]['_joinData']['permission_level'] > $container['permission_level']) {
+                    $MY_RIGHTS_LEVEL[(int)$childContainer['id']] = $containerPermissions[$childContainer['id']]['_joinData']['permission_level'];
+                }
             }
         }
-
         $userPermissions = [
             'MY_RIGHTS'         => array_unique($MY_RIGHTS),
             'MY_RIGHTS_LEVEL'   => $MY_RIGHTS_LEVEL,

--- a/src/itnovum/openITCOCKPIT/Core/PushrelayRequestHandler.php
+++ b/src/itnovum/openITCOCKPIT/Core/PushrelayRequestHandler.php
@@ -140,8 +140,8 @@ class PushrelayRequestHandler {
             ];
         } else {
             $options['proxy'] = [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ];
         }
         return $options;

--- a/src/itnovum/openITCOCKPIT/Graphite/GraphiteLoader.php
+++ b/src/itnovum/openITCOCKPIT/Graphite/GraphiteLoader.php
@@ -188,8 +188,8 @@ class GraphiteLoader {
             ];
         } else {
             $options['proxy'] = [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ];
         }
 

--- a/src/itnovum/openITCOCKPIT/Supervisor/BinarydAPI.php
+++ b/src/itnovum/openITCOCKPIT/Supervisor/BinarydAPI.php
@@ -24,8 +24,8 @@ class BinarydAPI {
         $this->Client = new Client([
             'base_uri' => $address,
             'proxy'    => [
-                'http'  => false,
-                'https' => false
+                'http'  => '',
+                'https' => ''
             ]
         ]);
     }


### PR DESCRIPTION
ITC-3608
* Remove CsrfMiddleware from the router where it does not belong.
* Add the CsrfMiddleware to the Application.php's MiddlewareQueue.
* Move the CsrfMiddleware to the end of the MiddlewareQueue.
* Use CakePHPs CsrfMiddleware->skipCheckCallback method to disable CSRF check when
  * User POSTs to services/index or hosts/index
  * Authentication is done by the ApikeyAuthenticator