### PR TITLE
Fix push agent host check exit code for stale agents

### DIFF
--- a/src/Command/AgentCommand.php
+++ b/src/Command/AgentCommand.php
@@ -51,7 +51,11 @@ use itnovum\openITCOCKPIT\Agent\AgentConfiguration;
 class AgentCommand extends Command {
 
     const RC_UP = 0;
-    const RC_DOWN = 1;
+    // Host checks must exit with code >= 2 to mark a host as DOWN.
+    // Naemon maps exit code 1 to WARNING and downgrades WARNING to UP
+    // unless use_aggressive_host_checking is enabled (see naemon-core
+    // checks_host.c, update_host_state_post_check).
+    const RC_DOWN = 2;
     const RC_UNREACHABLE = 2;
 
     const RC_OK = 0;


### PR DESCRIPTION
The host check variant of 'cake agent --check -H' exited with code 1 when the last agent update was older than the critical threshold. Naemon maps exit code 1 to WARNING for host checks and downgrades WARNING to UP unless use_aggressive_host_checking is enabled, so on installations with that setting disabled a host whose push agent stopped reporting stayed UP forever while the plugin output already said 'Down: ...'.

Exit with code 2 instead, which yields DOWN in both modes and matches the error paths of checkPushAgentFreshness() that already return RC_UNREACHABLE = 2.

Fixes #1980