### PR TITLE
ITC-3835: Core & Satellite API: Apikey Endpoint edits all fields

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -343,7 +343,8 @@ class ProfileController extends AppController {
             if (isset($data['id'])) {
                 $id = $data['id'];
 
-                if (!$ApikeysTable->existsById($id)) {
+                $apikey = $ApikeysTable->getApikeyByIdAndUserId($id, $User->getId());
+                if (empty($apikey)) {
                     throw new NotFoundException(__('Invalid API key'));
                 }
                 $apikey = $ApikeysTable->get($id);

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -347,8 +347,9 @@ class ProfileController extends AppController {
                 if (empty($apikey)) {
                     throw new NotFoundException(__('Invalid API key'));
                 }
-                $apikey = $ApikeysTable->get($id);
-                $apikey = $ApikeysTable->patchEntity($apikey, $data);
+                $apikey = $ApikeysTable->patchEntity($apikey, [
+                    'description' => $data['description'],
+                ]);
 
                 $ApikeysTable->save($apikey);
                 if ($apikey->hasErrors()) {

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 // 2.
 //	If you purchased an openITCOCKPIT Enterprise Edition you can use this file
@@ -356,12 +357,12 @@ class ProfileController extends AppController {
                     $this->response = $this->response->withStatus(400);
                     $this->set('error', $apikey->getErrors());
                     $this->viewBuilder()->setOption('serialize', ['error']);
-                    return;
-                } else {
-                    $this->set('message', __('API key updated successfully'));
-                    $this->viewBuilder()->setOption('serialize', ['message']);
+
                     return;
                 }
+                $this->set('message', __('API key updated successfully'));
+                $this->viewBuilder()->setOption('serialize', ['message']);
+
             }
 
         }


### PR DESCRIPTION
* Only edit APIKeys that are owned by the current user.
* Apply a sanitized patch to the Apikey Entity to only update the description field. The rest is readonly.
* Reformat code
* Lower cc