### PR TITLE
ITC-3843: Core: Security: Missing Container-Permissions Checks

### DIFF
--- a/src/Model/Behavior/ContainerOwnedBehavior.php
+++ b/src/Model/Behavior/ContainerOwnedBehavior.php
@@ -100,7 +100,7 @@ class ContainerOwnedBehavior extends Behavior {
 
         $containerIdsToCheck = [$containerId];
 
-        // Moving an entity out of a container requires write permissions to the old container as well.
+        // Changing the container needs write access to both containers.
         if (!$entity->isNew() && $entity->isDirty('container_id')) {
             $originalContainerId = (int)($entity->getOriginal('container_id') ?? 0);
             if ($originalContainerId > 0 && $originalContainerId !== $containerId) {

--- a/src/Model/Behavior/ContainerOwnedBehavior.php
+++ b/src/Model/Behavior/ContainerOwnedBehavior.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+// Copyright (C) 2015-2025  it-novum GmbH
+// Copyright (C) 2025-today AVENDIS GmbH
+//
+// This file is dual licensed
+//
+// 1.
+//     This program is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, version 3 of the License.
+//
+//     This program is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// 2.
+//     If you purchased an openITCOCKPIT Enterprise Edition you can use this file
+//     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
+//     License agreement and license key will be shipped with the order
+//     confirmation.
+//
+
+namespace App\Model\Behavior;
+
+use App\Controller\AppController;
+use App\itnovum\openITCOCKPIT\Core\Permissions\MyRightsFactory;
+use ArrayObject;
+use Cake\Cache\Cache;
+use Cake\Datasource\EntityInterface;
+use Cake\Event\EventInterface;
+use Cake\Http\Exception\UnauthorizedException;
+use Cake\ORM\Behavior;
+use Cake\Routing\Router;
+
+
+/**
+ * ContainerOwned Behavior
+ *
+ * I am the verification layer that makes it easy to limit write-access to Entities that belong to a single container.
+ *
+ */
+class ContainerOwnedBehavior extends Behavior {
+    public const SKIP_OWNERSHIP_CHECK = 'skip_ownership_check';
+
+    /**
+     * I will verify that the given $entity can be modified by the logged-in user.
+     * @throws UnauthorizedException In case the User has no permission to modify elements based on their container_id.
+     * @see ContainerOwnedBehavior::canEditEntity()
+     */
+    public function beforeDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
+        if (!$this->canEditEntity($event, $entity, $options)) {
+            throw new UnauthorizedException(__('Deleting not permitted: You do not have write permissions to the container_id') . ' #' . $entity->container_id);
+        }
+    }
+
+    /**
+     * I will verify that the given $entity can be modified by the logged-in user.
+     * @throws UnauthorizedException In case the User has no permission to modify elements based on their container_id.
+     * @see ContainerOwnedBehavior::canEditEntity()
+     */
+    public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
+        if (!$this->canEditEntity($event, $entity, $options)) {
+            throw new UnauthorizedException(__('Editing not permitted: You do not have write permissions to the container_id') . ' #' . $entity->container_id);
+        }
+    }
+
+    /**
+     * I will verify that the given $entity can be modified by the logged-in user.
+     * @param EventInterface $event
+     * @param EntityInterface $entity
+     * @param ArrayObject $options
+     * @return bool TRUE: The current user is allowed to edit the entity. FALSE: He is not.
+     */
+    private function canEditEntity(EventInterface $event, EntityInterface $entity, ArrayObject $options): bool {
+        // Skippable: CLI / cronjobs / setup / migrations and if you pass it explicitly.
+        if (($options[self::SKIP_OWNERSHIP_CHECK] ?? false) === true) {
+            return true;
+        }
+
+        // If container_id is not set, do not verify.
+        $containerId = (int)($entity->get('container_id') ?? 0);
+        if (!$containerId) {
+            return true;
+        }
+
+        $permissions = $this->getPermissions();
+        if ($permissions === null) {
+            // No request (CLI) - nothing to check
+            return true;
+        }
+
+        // hasRootPrivileges?
+        if (($permissions['hasRootPrivileges'] ?? false) === true) {
+            return true;
+        }
+
+        $containerIdsToCheck = [$containerId];
+
+        // Moving an entity out of a container requires write permissions to the old container as well.
+        if (!$entity->isNew() && $entity->isDirty('container_id')) {
+            $originalContainerId = (int)($entity->getOriginal('container_id') ?? 0);
+            if ($originalContainerId > 0 && $originalContainerId !== $containerId) {
+                $containerIdsToCheck[] = $originalContainerId;
+            }
+        }
+
+        foreach ($containerIdsToCheck as $containerIdToCheck) {
+            $permissionLevel = $permissions['MY_RIGHTS_LEVEL'][$containerIdToCheck] ?? null;
+            if ((int)$permissionLevel !== WRITE_RIGHT) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array|null
+     */
+    private function getPermissions(): ?array {
+        $identity = Router::getRequest()?->getAttribute('identity');
+        if ($identity === null) {
+            return null;
+        }
+
+        /**
+         * This is the same key as here:
+         * @see AppController::beforeFilter()
+         */
+        // Same cache key and cache config as used by AppController::beforeFilter()
+        $cacheKey = 'userPermissions_' . $identity->get('id');
+        $permissions = Cache::read($cacheKey, 'permissions');
+
+        // Fallback to put the userPermissions tot he cache if not cached previously.
+        if ($permissions === null) {
+            $permissions = MyRightsFactory::getUserPermissions($identity->get('id'), $identity->get('usergroup_id'));
+            Cache::write($cacheKey, $permissions, 'permissions');
+        }
+
+        return $permissions;
+    }
+
+}

--- a/src/Model/Behavior/ContainerOwnedBehavior.php
+++ b/src/Model/Behavior/ContainerOwnedBehavior.php
@@ -32,7 +32,7 @@ use ArrayObject;
 use Cake\Cache\Cache;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
-use Cake\Http\Exception\UnauthorizedException;
+use Cake\Http\Exception\ForbiddenException;
 use Cake\ORM\Behavior;
 use Cake\Routing\Router;
 
@@ -48,23 +48,23 @@ class ContainerOwnedBehavior extends Behavior {
 
     /**
      * I will verify that the given $entity can be modified by the logged-in user.
-     * @throws UnauthorizedException In case the User has no permission to modify elements based on their container_id.
+     * @throws ForbiddenException In case the User has no permission to modify elements based on their container_id.
      * @see ContainerOwnedBehavior::canEditEntity()
      */
     public function beforeDelete(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
         if (!$this->canEditEntity($event, $entity, $options)) {
-            throw new UnauthorizedException(__('Deleting not permitted: You do not have write permissions to the container_id') . ' #' . $entity->container_id);
+            throw new ForbiddenException(__('Deleting not permitted: You do not have write permissions to the container_id') . ' #' . $entity->container_id);
         }
     }
 
     /**
      * I will verify that the given $entity can be modified by the logged-in user.
-     * @throws UnauthorizedException In case the User has no permission to modify elements based on their container_id.
+     * @throws ForbiddenException In case the User has no permission to modify elements based on their container_id.
      * @see ContainerOwnedBehavior::canEditEntity()
      */
     public function beforeSave(EventInterface $event, EntityInterface $entity, ArrayObject $options): void {
         if (!$this->canEditEntity($event, $entity, $options)) {
-            throw new UnauthorizedException(__('Editing not permitted: You do not have write permissions to the container_id') . ' #' . $entity->container_id);
+            throw new ForbiddenException(__('Editing not permitted: You do not have write permissions to the container_id') . ' #' . $entity->container_id);
         }
     }
 
@@ -87,10 +87,15 @@ class ContainerOwnedBehavior extends Behavior {
             return true;
         }
 
+        if ($this->isConsoleContext()) {
+            // CLI / cronjobs / setup / migrations - nothing to check
+            return true;
+        }
+
         $permissions = $this->getPermissions();
         if ($permissions === null) {
-            // No request (CLI) - nothing to check
-            return true;
+            // Web request without an authenticated identity must never write container owned data
+            return false;
         }
 
         // hasRootPrivileges?
@@ -116,6 +121,15 @@ class ContainerOwnedBehavior extends Behavior {
         }
 
         return true;
+    }
+
+    /**
+     * I tell you whether we are running outside of a web request (console, cronjob, setup, migration).
+     * Those contexts are trusted, there is no user whose permissions could be checked.
+     * @return bool
+     */
+    private function isConsoleContext(): bool {
+        return PHP_SAPI === 'cli' || Router::getRequest() === null;
     }
 
     /**

--- a/src/Model/Table/AutomapsTable.php
+++ b/src/Model/Table/AutomapsTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
@@ -66,6 +67,7 @@ class AutomapsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('Containers', [
             'foreignKey' => 'container_id',

--- a/src/Model/Table/CalendarsTable.php
+++ b/src/Model/Table/CalendarsTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
@@ -74,6 +75,7 @@ class CalendarsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('Containers', [
             'foreignKey' => 'container_id',

--- a/src/Model/Table/DashboardTabAllocationsTable.php
+++ b/src/Model/Table/DashboardTabAllocationsTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 // 2.
 //	If you purchased an openITCOCKPIT Enterprise Edition you can use this file
@@ -34,6 +35,7 @@ declare(strict_types=1);
 namespace App\Model\Table;
 
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use Cake\Database\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -67,6 +69,7 @@ use itnovum\openITCOCKPIT\Filter\DashboardTabAllocationsFilter;
  * @method \App\Model\Entity\DashboardTabAllocation[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class DashboardTabAllocationsTable extends Table {
 
@@ -86,6 +89,7 @@ class DashboardTabAllocationsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('DashboardTabs', [
             'foreignKey' => 'dashboard_tab_id',

--- a/src/Model/Table/FilterBookmarkAllocationsTable.php
+++ b/src/Model/Table/FilterBookmarkAllocationsTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 // 2.
 //	If you purchased an openITCOCKPIT Enterprise Edition you can use this file
@@ -34,6 +35,7 @@ declare(strict_types=1);
 namespace App\Model\Table;
 
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use Cake\Database\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -67,6 +69,7 @@ use itnovum\openITCOCKPIT\Filter\BookmarkAllocationsFilter;
  * @method \App\Model\Entity\FilterBookmarkAllocation[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class FilterBookmarkAllocationsTable extends Table {
 
@@ -85,6 +88,7 @@ class FilterBookmarkAllocationsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('FilterBookmarks', [
             'foreignKey' => 'filter_bookmark_id',

--- a/src/Model/Table/HostescalationsTable.php
+++ b/src/Model/Table/HostescalationsTable.php
@@ -22,12 +22,14 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
 use App\Lib\Traits\Cake2ResultTableTrait;
 use App\Lib\Traits\CustomValidationTrait;
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -54,6 +56,7 @@ use itnovum\openITCOCKPIT\Filter\HostescalationsFilter;
  * @method \App\Model\Entity\Hostescalation findOrCreate($search, ?callable $callback = null, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class HostescalationsTable extends Table {
 
@@ -71,6 +74,7 @@ class HostescalationsTable extends Table {
     public function initialize(array $config): void {
         parent::initialize($config);
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->setTable('hostescalations');
         $this->setPrimaryKey('id');

--- a/src/Model/Table/HostsTable.php
+++ b/src/Model/Table/HostsTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
@@ -29,6 +30,7 @@ use App\Lib\Traits\Cake2ResultTableTrait;
 use App\Lib\Traits\CustomValidationTrait;
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
 use App\Lib\Traits\PluginManagerTableTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use App\Model\Entity\Changelog;
 use App\Model\Entity\Host;
 use App\Model\Entity\Hostdependency;
@@ -79,6 +81,7 @@ use itnovum\openITCOCKPIT\Filter\HostFilter;
  * @method Host[] patchEntities($entities, array $data, array $options = [])
  * @method Host findOrCreate($search, ?callable $callback = null, array $options = [])
  *
+ * @mixin ContainerOwnedBehavior
  * @mixin TimestampBehavior
  */
 class HostsTable extends Table {
@@ -102,6 +105,7 @@ class HostsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsToMany('HostsToContainersSharing', [
             'className'        => 'Containers',

--- a/src/Model/Table/HosttemplatesTable.php
+++ b/src/Model/Table/HosttemplatesTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
@@ -29,6 +30,7 @@ use App\Lib\Traits\Cake2ResultTableTrait;
 use App\Lib\Traits\CustomValidationTrait;
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
 use App\Lib\Traits\PluginManagerTableTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use App\Model\Entity\Changelog;
 use App\Model\Entity\Hosttemplate;
 use App\Model\Entity\User;
@@ -64,6 +66,7 @@ use itnovum\openITCOCKPIT\Filter\HosttemplateFilter;
  * @method \App\Model\Entity\Hosttemplate findOrCreate($search, ?callable $callback = null, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class HosttemplatesTable extends Table {
 
@@ -86,6 +89,7 @@ class HosttemplatesTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsToMany('Contactgroups', [
             'className'        => 'Contactgroups',

--- a/src/Model/Table/InstantreportsTable.php
+++ b/src/Model/Table/InstantreportsTable.php
@@ -22,11 +22,13 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
 use App\Lib\Traits\Cake2ResultTableTrait;
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use App\Model\Entity\Instantreport;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -52,6 +54,7 @@ use itnovum\openITCOCKPIT\Filter\InstantreportFilter;
  * @method \App\Model\Entity\Instantreport findOrCreate($search, ?callable $callback = null, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class InstantreportsTable extends Table {
     use Cake2ResultTableTrait;
@@ -71,6 +74,7 @@ class InstantreportsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('Containers', [
             'foreignKey' => 'container_id',

--- a/src/Model/Table/ServiceescalationsTable.php
+++ b/src/Model/Table/ServiceescalationsTable.php
@@ -22,12 +22,14 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
 use App\Lib\Traits\Cake2ResultTableTrait;
 use App\Lib\Traits\CustomValidationTrait;
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use Cake\Database\Expression\ComparisonExpression;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -55,6 +57,7 @@ use itnovum\openITCOCKPIT\Filter\ServiceescalationsFilter;
  * @method \App\Model\Entity\Serviceescalation findOrCreate($search, ?callable $callback = null, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class ServiceescalationsTable extends Table {
 
@@ -72,6 +75,7 @@ class ServiceescalationsTable extends Table {
     public function initialize(array $config): void {
         parent::initialize($config);
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->setTable('serviceescalations');
         $this->setPrimaryKey('id');

--- a/src/Model/Table/ServicetemplatesTable.php
+++ b/src/Model/Table/ServicetemplatesTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
@@ -29,6 +30,7 @@ use App\Lib\Traits\Cake2ResultTableTrait;
 use App\Lib\Traits\CustomValidationTrait;
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
 use App\Lib\Traits\PluginManagerTableTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use App\Model\Entity\Changelog;
 use App\Model\Entity\Servicetemplate;
 use Cake\Core\Plugin;
@@ -67,6 +69,7 @@ use itnovum\openITCOCKPIT\Filter\ServicetemplateFilter;
  * @method \App\Model\Entity\Servicetemplate findOrCreate($search, ?callable $callback = null, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class ServicetemplatesTable extends Table {
 
@@ -90,6 +93,7 @@ class ServicetemplatesTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsToMany('Contactgroups', [
             'className'        => 'Contactgroups',

--- a/src/Model/Table/StatuspagegroupsTable.php
+++ b/src/Model/Table/StatuspagegroupsTable.php
@@ -22,12 +22,14 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 declare(strict_types=1);
 
 namespace App\Model\Table;
 
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use App\Model\Entity\Statuspagegroup;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
@@ -60,6 +62,7 @@ use itnovum\openITCOCKPIT\Filter\GenericFilter;
  * @method iterable<\App\Model\Entity\Statuspagegroup>|\Cake\Datasource\ResultSetInterface<\App\Model\Entity\Statuspagegroup> deleteManyOrFail(iterable $entities, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class StatuspagegroupsTable extends Table {
     use PaginationAndScrollIndexTrait;
@@ -78,6 +81,7 @@ class StatuspagegroupsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('Containers', [
             'foreignKey' => 'container_id',

--- a/src/Model/Table/StatuspagesTable.php
+++ b/src/Model/Table/StatuspagesTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 // 2.
 //	If you purchased an openITCOCKPIT Enterprise Edition you can use this file
@@ -33,6 +34,7 @@ declare(strict_types=1);
 namespace App\Model\Table;
 
 use App\Lib\Traits\PaginationAndScrollIndexTrait;
+use App\Model\Behavior\ContainerOwnedBehavior;
 use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
@@ -69,6 +71,7 @@ use itnovum\openITCOCKPIT\Filter\StatuspagesFilter;
  * @method \App\Model\Entity\Statuspage[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehavior
  */
 class StatuspagesTable extends Table {
     use PaginationAndScrollIndexTrait;
@@ -87,6 +90,7 @@ class StatuspagesTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('Containers', [
             'foreignKey' => 'container_id',

--- a/src/Model/Table/TimeperiodsTable.php
+++ b/src/Model/Table/TimeperiodsTable.php
@@ -22,6 +22,7 @@
 //     under the terms of the openITCOCKPIT Enterprise Edition license agreement.
 //     License agreement and license key will be shipped with the order
 //     confirmation.
+//
 
 namespace App\Model\Table;
 
@@ -56,6 +57,7 @@ use itnovum\openITCOCKPIT\Filter\TimeperiodsFilter;
  * @method \App\Model\Entity\Timeperiod findOrCreate($search, ?callable $callback = null, array $options = [])
  *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
+ * @mixin ContainerOwnedBehaviors
  */
 class TimeperiodsTable extends Table {
 
@@ -77,6 +79,7 @@ class TimeperiodsTable extends Table {
         $this->setPrimaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('ContainerOwned');
 
         $this->belongsTo('Containers', [
             'foreignKey' => 'container_id',


### PR DESCRIPTION
* Add ContainerOwnedBehavior which verifies that a user has the permission to add/edit/delete an Entity based on its container_id
* Apply the ContainerOwnedBehavior to:
  * FilterBookmarkAllocationsTable
  * Hoststemplates
  * Hosts
  * Hostescalations
  * ServiceescalationsTable
  * ServicetemplatesTable
  * DashboardTabAllocationsTable
  * InstantreportsTable
  * StatuspagegroupsTable
  * Statuspages 
  * TimePeriodsTable
  * ServiceDependencies
  * Calendars

---
Clean version of #1997